### PR TITLE
Hooks

### DIFF
--- a/src/@lib/equalities/deepEquals.ts
+++ b/src/@lib/equalities/deepEquals.ts
@@ -1,3 +1,36 @@
 export function deepEquals<T>(objA: T, objB: T): boolean {
+  if (typeof objA !== typeof objB) {
+    return false;
+  }
+
+  if (Array.isArray(objA) && Array.isArray(objB)) {
+    if (objA.length !== objB.length) {
+      return false;
+    }
+    const sortedA = [...objA].sort();
+    const sortedB = [...objB].sort();
+    return sortedA.every((item, index) => deepEquals(item, sortedB[index]));
+  }
+
+  if (
+    typeof objA === "object" &&
+    typeof objB === "object" &&
+    objA !== null &&
+    objB !== null
+  ) {
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+
+    return keysA.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(objB, key) &&
+        deepEquals(objA[key as keyof T], objB[key as keyof T]),
+    );
+  }
+
   return objA === objB;
 }

--- a/src/@lib/equalities/shallowEquals.ts
+++ b/src/@lib/equalities/shallowEquals.ts
@@ -3,6 +3,10 @@ export function shallowEquals<T>(objA: T, objB: T): boolean {
     return false;
   }
 
+  if (objA === objB) {
+    return true;
+  }
+
   if (Array.isArray(objA) && Array.isArray(objB)) {
     if (objA.length !== objB.length) {
       return false;

--- a/src/@lib/equalities/shallowEquals.ts
+++ b/src/@lib/equalities/shallowEquals.ts
@@ -1,3 +1,36 @@
 export function shallowEquals<T>(objA: T, objB: T): boolean {
+  if (typeof objA !== typeof objB) {
+    return false;
+  }
+
+  if (Array.isArray(objA) && Array.isArray(objB)) {
+    if (objA.length !== objB.length) {
+      return false;
+    }
+    const sortedA = [...objA].sort();
+    const sortedB = [...objB].sort();
+    return sortedA.every((item, index) => item === sortedB[index]);
+  }
+
+  if (
+    typeof objA === "object" &&
+    typeof objB === "object" &&
+    objA !== null &&
+    objB !== null
+  ) {
+    const keysA = Object.keys(objA);
+    const keysB = Object.keys(objB);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+
+    return keysA.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(objB, key) &&
+        objA[key as keyof T] === objB[key as keyof T],
+    );
+  }
+
   return objA === objB;
 }

--- a/src/@lib/hooks/useCallback.ts
+++ b/src/@lib/hooks/useCallback.ts
@@ -1,10 +1,13 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import { DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(
   factory: T,
   _deps: DependencyList,
 ) {
-  // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  // 보통 useCallback을 사용할 때 factory 함수를 전역 함수로 정의한 후 넣지 않음.
+  // 그에 따라서 컴포넌트가 리렌더링 될 때마다 factory 함수가 생성 될 가능성이 높기 때문에 deps에 넣지 않음.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => factory, _deps);
 }

--- a/src/@lib/hooks/useMemo.ts
+++ b/src/@lib/hooks/useMemo.ts
@@ -1,12 +1,19 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { DependencyList } from "react";
 import { shallowEquals } from "../equalities";
+import { useRef } from "./useRef";
 
 export function useMemo<T>(
   factory: () => T,
   _deps: DependencyList,
   _equals = shallowEquals,
 ): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  const memoizedValue = useRef<T>();
+  const prevDeps = useRef<DependencyList>();
+
+  if (!_equals(prevDeps.current, _deps)) {
+    memoizedValue.current = factory();
+    prevDeps.current = _deps;
+  }
+
+  return memoizedValue.current as T;
 }

--- a/src/@lib/hooks/useRef.ts
+++ b/src/@lib/hooks/useRef.ts
@@ -1,6 +1,13 @@
+import { MutableRefObject, RefObject } from "react";
 import React from "react";
 
-export function useRef<T>(initialValue?: T): { current?: T } {
-  const [ref] = React.useState<{ current?: T }>({ current: initialValue });
+export function useRef<T>(initialValue: T): MutableRefObject<T>;
+export function useRef<T>(initialValue: T | null): RefObject<T>;
+export function useRef<T = undefined>(): MutableRefObject<T | undefined>;
+
+export function useRef<T>(initialValue?: T) {
+  const [ref] = React.useState<{ current?: T }>({
+    current: initialValue,
+  });
   return ref;
 }

--- a/src/@lib/hooks/useRef.ts
+++ b/src/@lib/hooks/useRef.ts
@@ -1,4 +1,6 @@
+import React from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
-  // React의 useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  const [ref] = React.useState({ current: initialValue });
+  return ref;
 }

--- a/src/@lib/hooks/useRef.ts
+++ b/src/@lib/hooks/useRef.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-export function useRef<T>(initialValue: T): { current: T } {
-  const [ref] = React.useState({ current: initialValue });
+export function useRef<T>(initialValue?: T): { current?: T } {
+  const [ref] = React.useState<{ current?: T }>({ current: initialValue });
   return ref;
 }

--- a/src/__tests__/basic.test.tsx
+++ b/src/__tests__/basic.test.tsx
@@ -570,6 +570,26 @@ describe("Chapter 1-3 기본과제: hooks 구현하기 > ", () => {
           ref.current?.updateDeps([[1, 2, 3]]);
         });
         expect(mockFactory).toHaveBeenCalledTimes(4);
+
+        act(() => {
+          ref.current?.updateDeps([[1, [2, 3]]]);
+        });
+        expect(mockFactory).toHaveBeenCalledTimes(5);
+
+        act(() => {
+          ref.current?.updateDeps([[1, [2, 3]]]);
+        });
+        expect(mockFactory).toHaveBeenCalledTimes(5);
+
+        act(() => {
+          ref.current?.updateDeps([{ a: { b: 1 } }]);
+        });
+        expect(mockFactory).toHaveBeenCalledTimes(6);
+
+        act(() => {
+          ref.current?.updateDeps([{ a: { b: 1 } }]);
+        });
+        expect(mockFactory).toHaveBeenCalledTimes(6);
       });
     });
   });


### PR DESCRIPTION
```js
const keysA = Object.keys(objA);
const keysB = Object.keys(objB);

keysA.every(
  (key) =>
    Object.prototype.hasOwnProperty.call(objB, key) &&
    objA[key as keyof T] === objB[key as keyof T],
);
```
객체가 가진 키를 비교하기 위해 `Object.prototype.hasOwnProperty.call(objB, key)`를 넣은 이유
- Object.keys()는 객체 자신의 열거 가능 속성만 반환하는데, `objA[key]`처럼 직접 속성 접근은 프로토타입 체인을 통해서 상속된 속성에도 접근이 된다.

```js
const proto = { sharedProp: 'value' };

const objA = Object.create(proto);
const objB = Object.create(proto);

objA.ownProp = 1;

console.log(Object.keys(objA)) // ['ownProp']
console.log(objA.sharedProp) // 'value'
console.log(Object.prototype.hasOwnProperty.call(objA, "sharedProp")) // false
```
`objA.hasOwnProperty(key)`로 사용하지 않은 이유
- objA 객체에 hasOwnProperty 메소드를 재정의하는 가능성도 있기 때문이다.
```js
console.log(objA.hasOwnProperty("ownProp")) // true

objA.hasOwnProperty = () => false

console.log(objA.hasOwnProperty("ownProp")) // false
```
es2022 에서는 `Object.hasOwn(objA, key)`로 사용할 수 있다. 과제는 tsconfig에서 2020으로 컴파일 설정이 되어있어서 `Object.hasOwn`을 사용하지 못한다