### PR TITLE
Hoc

### DIFF
--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -1,10 +1,24 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { shallowEquals } from "../equalities";
-import { ComponentType } from "react";
+import { ComponentType, createElement, ReactElement } from "react";
+import { useRef } from "../hooks";
 
 export function memo<P extends object>(
   Component: ComponentType<P>,
   _equals = shallowEquals,
 ) {
-  return Component;
+  return (props: P) => {
+    const memoizedProps = useRef<P>(props);
+    const memoizedComponent = useRef<ReactElement<P>>();
+
+    if (!memoizedComponent.current) {
+      memoizedComponent.current = createElement<P>(Component, props);
+    }
+
+    if (!_equals(memoizedProps.current, props)) {
+      memoizedProps.current = props;
+      memoizedComponent.current = createElement<P>(Component, props);
+    }
+
+    return memoizedComponent.current;
+  };
 }

--- a/src/@lib/hocs/memo.ts
+++ b/src/@lib/hocs/memo.ts
@@ -1,24 +1,24 @@
 import { shallowEquals } from "../equalities";
 import { ComponentType, createElement, ReactElement } from "react";
-import { useRef } from "../hooks";
 
 export function memo<P extends object>(
   Component: ComponentType<P>,
   _equals = shallowEquals,
 ) {
+  let memoizedProps: P | null = null;
+  let memoizedComponent: ReactElement<P> | null = null;
+
   return (props: P) => {
-    const memoizedProps = useRef<P>(props);
-    const memoizedComponent = useRef<ReactElement<P>>();
-
-    if (!memoizedComponent.current) {
-      memoizedComponent.current = createElement<P>(Component, props);
+    if (!memoizedProps) {
+      memoizedProps = props;
+      memoizedComponent = createElement<P>(Component, props);
     }
 
-    if (!_equals(memoizedProps.current, props)) {
-      memoizedProps.current = props;
-      memoizedComponent.current = createElement<P>(Component, props);
+    if (!_equals(memoizedProps, props)) {
+      memoizedProps = props;
+      memoizedComponent = createElement<P>(Component, props);
     }
 
-    return memoizedComponent.current;
+    return memoizedComponent;
   };
 }


### PR DESCRIPTION
```js
export function memo<P extends object>(
  Component: ComponentType<P>,
  _equals = shallowEquals,
) {
  return (props: P) => {
    const memoizedProps = useRef<P>(props);
    const memoizedComponent = useRef<ReactElement<P>>();
    if (!memoizedComponent.current) {
      memoizedComponent.current = createElement<P>(Component, props);
    }
    if (!_equals(memoizedProps.current, props)) {
      memoizedProps.current = props;
      memoizedComponent.current = createElement<P>(Component, props);
    }
    return memoizedComponent.current;
  };
}
```
처음 구현은 useRef를 사용해서 리렌더링이 되더라도 값을 기억하도록 구현하였다.
React.memo는 hooks가 나오기 전에도 있었던 것으로 기억해서 useRef를 사용하지 않고 구현해 보고 싶었고, 
값을 캡슐화 할 수 있는 클로저 방식이 가장 먼저 떠올랐다.

클로저 방식 구현 하기 전에 리렌더링 시마다 memo가 계속 불려서 캡슐화가 안되지 않을까?라는 생각이 들었는데,
`React.memo`를 사용할 때 
```js
const MemoComponent = React.memo(Component)

const App = () => {
  return (
    <MemoComponent />
  )
}

``` 
이렇게 memo 함수의 리턴 값인 컴포넌트를 사용하게 됨으로 리렌더링 때 memo가 매번 호출되지 않을 것으로 예상하고 클로저 방식으로 수정하였고, 테스트는 잘 통과 되었다.

```js
export function memo<P extends object>(
  Component: ComponentType<P>,
  _equals = shallowEquals,
) {
  let memoizedProps: P | null = null;
  let memoizedComponent: ReactElement<P> | null = null;

  return (props: P) => {
    if (!memoizedProps) {
      memoizedProps = props;
      memoizedComponent = createElement<P>(Component, props);
    }

    if (!_equals(memoizedProps, props)) {
      memoizedProps = props;
      memoizedComponent = createElement<P>(Component, props);
    }

    return memoizedComponent;
  };
}
```

