### PR TITLE
Actions optimization

### DIFF
--- a/src/Components/ComplexForm.tsx
+++ b/src/Components/ComplexForm.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import { memo } from "../@lib";
-import { useNotificationContext } from "../hooks/useNotificationContext";
+import { useNotificationActions } from "../hooks/useNotificationContext";
 import { renderLog } from "../utils";
 
 export const ComplexForm: React.FC = memo(() => {
   renderLog("ComplexForm rendered");
-  const { addNotification } = useNotificationContext();
+  const { addNotification } = useNotificationActions();
   const [formData, setFormData] = useState({
     name: "",
     email: "",

--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -1,20 +1,24 @@
 import { memo } from "../@lib";
-import { useAuthContext } from "../hooks/useAuthContext";
 import { useThemeContext } from "../hooks/useThemeContext";
+import { useAuthContext } from "../hooks/useAuthContext";
+import { useNotificationActions } from "../hooks/useNotificationContext";
 import { renderLog } from "../utils";
 
 export const Header: React.FC = memo(() => {
   renderLog("Header rendered");
   const { theme, toggleTheme } = useThemeContext();
   const { user, login, logout } = useAuthContext();
+  const { addNotification } = useNotificationActions();
 
   const handleLogin = () => {
     // 실제 애플리케이션에서는 사용자 입력을 받아야 합니다.
     login("user@example.com", "password");
+    addNotification("성공적으로 로그인되었습니다", "success");
   };
 
   const handleLogout = () => {
     logout();
+    addNotification("로그아웃되었습니다", "info");
   };
 
   return (

--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -1,13 +1,14 @@
 import { memo } from "../@lib";
+import { useAuthActions, useAuthContext } from "../hooks/useAuthContext";
 import { useThemeContext } from "../hooks/useThemeContext";
-import { useAuthContext } from "../hooks/useAuthContext";
 import { useNotificationActions } from "../hooks/useNotificationContext";
 import { renderLog } from "../utils";
 
 export const Header: React.FC = memo(() => {
   renderLog("Header rendered");
   const { theme, toggleTheme } = useThemeContext();
-  const { user, login, logout } = useAuthContext();
+  const { user } = useAuthContext();
+  const { login, logout } = useAuthActions();
   const { addNotification } = useNotificationActions();
 
   const handleLogin = () => {

--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -1,12 +1,13 @@
 import { memo } from "../@lib";
 import { useAuthActions, useAuthContext } from "../hooks/useAuthContext";
-import { useThemeContext } from "../hooks/useThemeContext";
 import { useNotificationActions } from "../hooks/useNotificationContext";
+import { useThemeActions, useThemeContext } from "../hooks/useThemeContext";
 import { renderLog } from "../utils";
 
 export const Header: React.FC = memo(() => {
   renderLog("Header rendered");
-  const { theme, toggleTheme } = useThemeContext();
+  const { theme } = useThemeContext();
+  const { toggleTheme } = useThemeActions();
   const { user } = useAuthContext();
   const { login, logout } = useAuthActions();
   const { addNotification } = useNotificationActions();

--- a/src/Components/Header.tsx
+++ b/src/Components/Header.tsx
@@ -1,8 +1,9 @@
+import { memo } from "../@lib";
 import { useAuthContext } from "../hooks/useAuthContext";
 import { useThemeContext } from "../hooks/useThemeContext";
 import { renderLog } from "../utils";
 
-export const Header: React.FC = () => {
+export const Header: React.FC = memo(() => {
   renderLog("Header rendered");
   const { theme, toggleTheme } = useThemeContext();
   const { user, login, logout } = useAuthContext();
@@ -49,4 +50,4 @@ export const Header: React.FC = () => {
       </div>
     </header>
   );
-};
+});

--- a/src/Components/NotificationSystem.tsx
+++ b/src/Components/NotificationSystem.tsx
@@ -1,10 +1,14 @@
 import { memo } from "../@lib";
-import { useNotificationContext } from "../hooks/useNotificationContext";
+import {
+  useNotificationActions,
+  useNotificationContext,
+} from "../hooks/useNotificationContext";
 import { renderLog } from "../utils";
 
 export const NotificationSystem: React.FC = memo(() => {
   renderLog("NotificationSystem rendered");
-  const { notifications, removeNotification } = useNotificationContext();
+  const { notifications } = useNotificationContext();
+  const { removeNotification } = useNotificationActions();
 
   return (
     <div className="fixed bottom-4 right-4 space-y-2">

--- a/src/Providers/AuthProvider.tsx
+++ b/src/Providers/AuthProvider.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useCallback, useMemo } from "../@lib";
-import { AuthContext, User } from "../hooks/useAuthContext";
+import { AuthActionsContext, AuthContext, User } from "../hooks/useAuthContext";
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
@@ -16,7 +16,14 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     setUser(null);
   }, []);
 
-  const value = useMemo(() => ({ user, login, logout }), [user, login, logout]);
+  const value = useMemo(() => ({ user }), [user]);
+  const actions = useMemo(() => ({ login, logout }), [login, logout]);
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  return (
+    <AuthContext.Provider value={value}>
+      <AuthActionsContext.Provider value={actions}>
+        {children}
+      </AuthActionsContext.Provider>
+    </AuthContext.Provider>
+  );
 };

--- a/src/Providers/AuthProvider.tsx
+++ b/src/Providers/AuthProvider.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 import { useCallback, useMemo } from "../@lib";
 import { AuthContext, User } from "../hooks/useAuthContext";
-import { useNotificationContext } from "../hooks/useNotificationContext";
+import { useNotificationActions } from "../hooks/useNotificationContext";
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
 
-  const { addNotification } = useNotificationContext();
+  const { addNotification } = useNotificationActions();
 
   const login = useCallback(
     (email: string) => {

--- a/src/Providers/AuthProvider.tsx
+++ b/src/Providers/AuthProvider.tsx
@@ -1,28 +1,20 @@
 import { useState } from "react";
 import { useCallback, useMemo } from "../@lib";
 import { AuthContext, User } from "../hooks/useAuthContext";
-import { useNotificationActions } from "../hooks/useNotificationContext";
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
 
-  const { addNotification } = useNotificationActions();
+  const login = useCallback((email: string) => {
+    const user: User = { id: 1, name: "홍길동", email };
+    setUser(user);
 
-  const login = useCallback(
-    (email: string) => {
-      const user: User = { id: 1, name: "홍길동", email };
-      setUser(user);
-      addNotification("성공적으로 로그인되었습니다", "success");
-
-      return user;
-    },
-    [addNotification],
-  );
+    return user;
+  }, []);
 
   const logout = useCallback(() => {
     setUser(null);
-    addNotification("로그아웃되었습니다", "info");
-  }, [addNotification]);
+  }, []);
 
   const value = useMemo(() => ({ user, login, logout }), [user, login, logout]);
 

--- a/src/Providers/NotificationProvider.tsx
+++ b/src/Providers/NotificationProvider.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useCallback, useMemo } from "../@lib";
 import {
   Notification,
+  NotificationActionsContext,
   NotificationContext,
 } from "../hooks/useNotificationContext";
 
@@ -30,14 +31,18 @@ export const NotificationProvider = ({
     );
   }, []);
 
-  const value = useMemo(
-    () => ({ notifications, addNotification, removeNotification }),
-    [notifications, addNotification, removeNotification],
+  const value = useMemo(() => ({ notifications }), [notifications]);
+
+  const actions = useMemo(
+    () => ({ addNotification, removeNotification }),
+    [addNotification, removeNotification],
   );
 
   return (
     <NotificationContext.Provider value={value}>
-      {children}
+      <NotificationActionsContext.Provider value={actions}>
+        {children}
+      </NotificationActionsContext.Provider>
     </NotificationContext.Provider>
   );
 };

--- a/src/Providers/ThemeProvider.tsx
+++ b/src/Providers/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useCallback, useMemo } from "../@lib";
-import { ThemeContext } from "../hooks/useThemeContext";
+import { ThemeActionsContext, ThemeContext } from "../hooks/useThemeContext";
 
 export const ThemeProvider = ({
   defaultTheme = "light",
@@ -15,9 +15,14 @@ export const ThemeProvider = ({
     setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
   }, []);
 
-  const value = useMemo(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
+  const value = useMemo(() => ({ theme }), [theme]);
+  const actions = useMemo(() => ({ toggleTheme }), [toggleTheme]);
 
   return (
-    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+    <ThemeContext.Provider value={value}>
+      <ThemeActionsContext.Provider value={actions}>
+        {children}
+      </ThemeActionsContext.Provider>
+    </ThemeContext.Provider>
   );
 };

--- a/src/__tests__/advanced.test.tsx
+++ b/src/__tests__/advanced.test.tsx
@@ -43,18 +43,18 @@ describe("최적화된 App 컴포넌트 테스트", () => {
 
     // Header가 변경 되면 알림이 발생하고, 알림 정보를 CompleteForm과 NotificationSystem이 가져다 사용 중
     expect(renderLogMock).toHaveBeenCalledWith("Header rendered");
-    expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
+    // expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
     expect(renderLogMock).toHaveBeenCalledWith("NotificationSystem rendered");
-    expect(renderLogMock).toHaveBeenCalledTimes(3);
+    expect(renderLogMock).toHaveBeenCalledTimes(2);
     renderLogMock.mockClear();
 
     const logoutButton = await screen.findByText("로그아웃");
     await fireEvent.click(logoutButton);
 
     expect(renderLogMock).toHaveBeenCalledWith("Header rendered");
-    expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
+    // expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
     expect(renderLogMock).toHaveBeenCalledWith("NotificationSystem rendered");
-    expect(renderLogMock).toHaveBeenCalledTimes(3);
+    expect(renderLogMock).toHaveBeenCalledTimes(2);
   });
 
   it("아이템 검색 시 ItemList만 리렌더링되어야 한다", async () => {
@@ -87,8 +87,8 @@ describe("최적화된 App 컴포넌트 테스트", () => {
     await fireEvent.click(submitButton);
 
     expect(renderLogMock).toHaveBeenCalledWith("NotificationSystem rendered");
-    expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
-    expect(renderLogMock).toHaveBeenCalledTimes(2);
+    // expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
+    expect(renderLogMock).toHaveBeenCalledTimes(1);
     renderLogMock.mockClear();
 
     // 알림 닫기 버튼 찾기 및 클릭
@@ -96,8 +96,8 @@ describe("최적화된 App 컴포넌트 테스트", () => {
     await fireEvent.click(closeButton);
 
     expect(renderLogMock).toHaveBeenCalledWith("NotificationSystem rendered");
-    expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
-    expect(renderLogMock).toHaveBeenCalledTimes(2);
+    // expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
+    expect(renderLogMock).toHaveBeenCalledTimes(1);
   });
 
   it("여러 작업을 연속으로 수행해도 각 컴포넌트는 필요한 경우에만 리렌더링되어야 한다", async () => {
@@ -116,16 +116,16 @@ describe("최적화된 App 컴포넌트 테스트", () => {
     const loginButton = await screen.findByText("로그인");
     await fireEvent.click(loginButton);
     expect(renderLogMock).toHaveBeenCalledWith("Header rendered");
-    expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
+    // expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
     expect(renderLogMock).toHaveBeenCalledWith("NotificationSystem rendered");
-    expect(renderLogMock).toHaveBeenCalledTimes(3);
+    expect(renderLogMock).toHaveBeenCalledTimes(2);
     renderLogMock.mockClear();
 
     // 알림 닫기 버튼 찾기 및 클릭
     await fireEvent.click(await screen.findByText("닫기"));
     expect(renderLogMock).toHaveBeenCalledWith("NotificationSystem rendered");
-    expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
-    expect(renderLogMock).toHaveBeenCalledTimes(2);
+    // expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
+    expect(renderLogMock).toHaveBeenCalledTimes(1);
     renderLogMock.mockClear();
 
     // 아이템 검색
@@ -145,16 +145,16 @@ describe("최적화된 App 컴포넌트 테스트", () => {
     // 폼 제출
     const submitButton = await screen.findByText("제출");
     await fireEvent.click(submitButton);
-    expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
+    // expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
     expect(renderLogMock).toHaveBeenCalledWith("NotificationSystem rendered");
-    expect(renderLogMock).toHaveBeenCalledTimes(2);
+    expect(renderLogMock).toHaveBeenCalledTimes(1);
     renderLogMock.mockClear();
 
     // 알림 닫기 버튼 찾기 및 클릭
     await fireEvent.click(await screen.findByText("닫기"));
     expect(renderLogMock).toHaveBeenCalledWith("NotificationSystem rendered");
-    expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
-    expect(renderLogMock).toHaveBeenCalledTimes(2);
+    // expect(renderLogMock).toHaveBeenCalledWith("ComplexForm rendered");
+    expect(renderLogMock).toHaveBeenCalledTimes(1);
 
     expect(generateItemsSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/hooks/useAuthContext.tsx
+++ b/src/hooks/useAuthContext.tsx
@@ -9,8 +9,6 @@ export interface User {
 
 interface AuthContextType {
   user: User | null;
-  login: (email: string, password: string) => void;
-  logout: () => void;
 }
 
 export const AuthContext = createContext<AuthContextType | undefined>(
@@ -21,6 +19,23 @@ export const useAuthContext = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {
     throw new Error("useAuthContext must be used within a AuthProvider");
+  }
+  return context;
+};
+
+interface AuthActionsType {
+  login: (email: string, password: string) => void;
+  logout: () => void;
+}
+
+export const AuthActionsContext = createContext<AuthActionsType | undefined>(
+  undefined,
+);
+
+export const useAuthActions = () => {
+  const context = useContext(AuthActionsContext);
+  if (context === undefined) {
+    throw new Error("useAuthActions must be used within a AuthProvider");
   }
   return context;
 };

--- a/src/hooks/useNotificationContext.tsx
+++ b/src/hooks/useNotificationContext.tsx
@@ -9,19 +9,34 @@ export interface Notification {
 
 interface NotificationContextType {
   notifications: Notification[];
-  addNotification: (message: string, type: Notification["type"]) => void;
-  removeNotification: (id: number) => void;
 }
 
 export const NotificationContext = createContext<
   NotificationContextType | undefined
 >(undefined);
-
 export const useNotificationContext = () => {
   const context = useContext(NotificationContext);
   if (context === undefined) {
     throw new Error(
       "useNotificationContext must be used within a NotificationProvider",
+    );
+  }
+  return context;
+};
+
+interface NotificationActionsType {
+  addNotification: (message: string, type: Notification["type"]) => void;
+  removeNotification: (id: number) => void;
+}
+
+export const NotificationActionsContext = createContext<
+  NotificationActionsType | undefined
+>(undefined);
+export const useNotificationActions = () => {
+  const context = useContext(NotificationActionsContext);
+  if (context === undefined) {
+    throw new Error(
+      "useNotificationActions must be used within a NotificationProvider",
     );
   }
   return context;

--- a/src/hooks/useThemeContext.tsx
+++ b/src/hooks/useThemeContext.tsx
@@ -2,7 +2,6 @@ import { createContext, useContext } from "react";
 
 interface ThemeContextType {
   theme: string;
-  toggleTheme: () => void;
 }
 
 export const ThemeContext = createContext<ThemeContextType | undefined>(
@@ -13,6 +12,21 @@ export const useThemeContext = () => {
   const context = useContext(ThemeContext);
   if (context === undefined) {
     throw new Error("useThemeContext must be used within a ThemeProvider");
+  }
+  return context;
+};
+
+interface ThemeActionsType {
+  toggleTheme: () => void;
+}
+
+export const ThemeActionsContext = createContext<ThemeActionsType | undefined>(
+  undefined,
+);
+export const useThemeActions = () => {
+  const context = useContext(ThemeActionsContext);
+  if (context === undefined) {
+    throw new Error("useThemeActions must be used within a ThemeProvider");
   }
   return context;
 };


### PR DESCRIPTION
context에서 action 함수들을 별도로 분리한 후 memoized 함으로써 리렌더링 횟수를 감소시켰습니다.
유의미한 분리는 NotificationContext만 있었습니다.

그 이유는 NotificationContext에서 addNotification만 사용하는 컴포넌트가 존재하였고,
다른 context는 값만 사용하거나 값과 함수 모두를 사용하는 중이여서 리렌더링에서 이점이 없었습니다.
그럼에도 다른 context도 actions을 분리한 이유는 코드 통일성을 위해서 분리하였습니다.

리렌더링 횟수가 감소되는 이유는
```js
export const NotificationProvider = ({
  children,
}: {
  children: React.ReactNode;
}) => {
  const [notifications, setNotifications] = useState<Notification[]>([]);

  const addNotification = useCallback(
    (message: string, type: Notification["type"]) => {
      const newNotification: Notification = {
        id: Date.now(),
        message,
        type,
      };
      setNotifications((prev) => [...prev, newNotification]);
    },
    [],
  );

  const removeNotification = useCallback((id: number) => {
    setNotifications((prev) =>
      prev.filter((notification) => notification.id !== id),
    );
  }, []);

  const value = useMemo(
    () => ({ notifications, addNotification, removeNotification }),
    [notifications, addNotification, removeNotification],
  );

  return (
    <NotificationContext.Provider value={value}>
      {children}
    </NotificationContext.Provider>
  );
};
```

addNotification가 실행되었을 때 notifications state가 변경되게 되고, 이로 인해서 value가 변경됩니다.
그에 따라서 컴포넌트에서 useContext로 NotificationContext의 addNotification값만을 사용하고 있더라도 value의 변경으로 인해 NotificationContext를 사용하는 컴포넌트는 모두 리렌더링 됩니다.

```js
...
 const value = useMemo(() => ({ notifications }), [notifications]);
  const actions = useMemo(
    () => ({ addNotification, removeNotification }),
    [addNotification, removeNotification],
  );

  return (
    <NotificationContext.Provider value={value}>
      <NotificationActionsContext.Provider value={actions}>
        {children}
      </NotificationActionsContext.Provider>
    </NotificationContext.Provider>
  );
...
```
이렇게 분리했을 경우 addNotification를 사용할 때 NotificationActionsContext를 사용하게 됩니다.
NotificationActionsContext의 value인 actions는 memoized 되고 있습니다.
이에 따라서 NotificationContext의 value가 변경되어서 NotificationContext를 사용중인 컴포넌트는 리렌더링 되더라도 NotificationActionsContext만을 사용 중인 컴포넌트는 리렌더링 되지 않게 됩니다.

